### PR TITLE
Add compatibility with django 3.x

### DIFF
--- a/health_check/templates/health_check/base.html
+++ b/health_check/templates/health_check/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 <!doctype html>
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->

--- a/health_check/templates/health_check/health.html
+++ b/health_check/templates/health_check/health.html
@@ -1,5 +1,5 @@
 {% extends "health_check/base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
   <div id="app"></div>

--- a/health_check/templates/health_check/main.html
+++ b/health_check/templates/health_check/main.html
@@ -1,5 +1,5 @@
 {% extends "health_check/base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
   <div id="app"></div>

--- a/health_check/templates/health_check/stats.html
+++ b/health_check/templates/health_check/stats.html
@@ -1,5 +1,5 @@
 {% extends "health_check/base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block content %}
   <div id="app"></div>


### PR DESCRIPTION
Due to change in django 3 (https://docs.djangoproject.com/en/dev/releases/3.0/#features-removed-in-3-0), 
`{% load staticfiles %}` must be replaced by `{% load static %}`